### PR TITLE
Fix Runme binary download race

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -16,13 +16,14 @@ import { SUPPORTE_PLATFORMS } from './constants.js'
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 const streamPipeline = util.promisify(stream.pipeline)
+const DEFAULT_RUNME_DOWNLOAD_BASE_URL = 'https://downloads.runme.dev/runme'
 
 /**
  * download runme binary from GitHub
  * @returns file path to downloaded binary
  */
 export async function download (runmeVersion = process.env.RUNME_VERSION || 'latest') {
-  const targetDir = path.resolve(__dirname, '..', '.bin')
+  const targetDir = path.resolve(process.env.RUNME_BIN_DIR || path.resolve(__dirname, '..', '.bin'))
   const isWindows = os.platform() === 'win32'
   const binaryFilePath = path.resolve(targetDir, `runme${isWindows ? '.exe' : ''}`)
 
@@ -36,7 +37,8 @@ export async function download (runmeVersion = process.env.RUNME_VERSION || 'lat
   }
 
   const [version, type, target, ext] = [runmeVersion, platform.TYPE.toLocaleLowerCase(), platform.TARGET, platform.EXTENSION]
-  const url = `https://download.stateful.com/runme/${version}/runme_${type.replace('_nt', '')}_${target}.${ext}`
+  const downloadBaseUrl = (process.env.RUNME_DOWNLOAD_BASE_URL || DEFAULT_RUNME_DOWNLOAD_BASE_URL).replace(/\/$/, '')
+  const url = `${downloadBaseUrl}/${version}/runme_${type.replace('_nt', '')}_${target}.${ext}`
   const res = await fetch(url)
 
   if (!res.body) {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,6 +1,7 @@
 import cp from 'node:child_process'
 import { describe, it, expect, vi, afterAll } from 'vitest'
 
+import { download } from '../src/installer.js'
 import { runme } from '../src/cli.js'
 
 vi.mock('node:child_process', () => ({
@@ -10,21 +11,18 @@ vi.mock('node:child_process', () => ({
   }
 }))
 
-vi.mock('node:os', () => ({
-  default: {
-    type: vi.fn().mockReturnValue('Darwin'),
-    arch: () => 'arm64',
-    platform: vi.fn().mockReturnValue('darwin')
-  }
+vi.mock('../src/installer.js', () => ({
+  download: vi.fn().mockResolvedValue('/tmp/runme')
 }))
 
 describe('RunmeJS CLI', () => {
   it('supports defauls from config file', async () => {
     process.argv = ['nodepath', 'binPath', 'run', '--chdir=./examples', '--filename=example.md']
     await runme()
+    expect(download).toBeCalledTimes(1)
     expect(
       vi.mocked(cp.spawn).mock.calls[0][0]
-        .endsWith('.bin/runme run --chdir=./examples --filename=example.md')
+        .endsWith('/tmp/runme run --chdir=./examples --filename=example.md')
     ).toBe(true)
   })
 })

--- a/tests/download.test.ts
+++ b/tests/download.test.ts
@@ -2,7 +2,7 @@ import os from 'node:os'
 import fs from 'node:fs/promises'
 import cp from 'node:child_process'
 
-import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest'
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest'
 import fetch from 'node-fetch'
 
 import { download } from '../src/installer.js'
@@ -49,6 +49,18 @@ beforeAll(() => {
   console.table = vi.fn()
 })
 
+beforeEach(() => {
+  delete process.env.RUNME_BIN_DIR
+  delete process.env.RUNME_DOWNLOAD_BASE_URL
+  vi.mocked(fs.access).mockResolvedValue(undefined)
+  vi.mocked(fs.mkdir).mockClear()
+  vi.mocked(fetch).mockClear()
+  vi.mocked(os.type).mockReturnValue('Darwin')
+  vi.mocked(os.platform).mockReturnValue('darwin')
+  vi.mocked(console.log).mockClear()
+  vi.mocked(console.table).mockClear()
+})
+
 describe('CLI Download', () => {
   it('does not download if already downloaded', async () => {
     expect(await download()).toStrictEqual(expect.any(String))
@@ -71,10 +83,30 @@ describe('CLI Download', () => {
     vi.mocked(fs.access).mockRejectedValue(new Error('ups'))
     expect(await download()).toStrictEqual(expect.any(String))
     expect(fetch).toBeCalledTimes(1)
+    expect(vi.mocked(fetch).mock.calls[0][0]).toContain('https://downloads.runme.dev/runme/latest/')
     expect(vi.mocked(fetch).mock.calls[0][0]).toContain('runme_darwin_arm64.tar.gz')
   })
 
+  it('supports custom download base URLs', async () => {
+    process.env.RUNME_DOWNLOAD_BASE_URL = 'https://example.com/runme'
+    vi.mocked(fs.access).mockRejectedValue(new Error('ups'))
+    vi.mocked(fetch).mockClear()
+
+    expect(await download('3.17.1')).toStrictEqual(expect.any(String))
+    expect(vi.mocked(fetch).mock.calls[0][0])
+      .toBe('https://example.com/runme/3.17.1/runme_darwin_arm64.tar.gz')
+  })
+
+  it('supports custom binary directories', async () => {
+    process.env.RUNME_BIN_DIR = '/tmp/runmejs-test-bin'
+    vi.mocked(fs.access).mockRejectedValue(new Error('ups'))
+
+    expect(await download()).toBe('/tmp/runmejs-test-bin/runme')
+    expect(fs.mkdir).toBeCalledWith('/tmp/runmejs-test-bin', { recursive: true })
+  })
+
   it('fails if environment is not supported', async () => {
+    vi.mocked(fs.access).mockRejectedValue(new Error('ups'))
     vi.mocked(os.type).mockReturnValue('foobar')
     await expect(download()).rejects.toThrow(/Platform not supported/)
     expect(console.log).toBeCalledTimes(1)
@@ -85,6 +117,8 @@ describe('CLI Download', () => {
 })
 
 afterAll(() => {
+  delete process.env.RUNME_BIN_DIR
+  delete process.env.RUNME_DOWNLOAD_BASE_URL
   vi.restoreAllMocks()
   console.log = consoleLog
   console.table = consoleTable

--- a/tests/module.test.ts
+++ b/tests/module.test.ts
@@ -1,17 +1,25 @@
 import fs from 'node:fs/promises'
-import url from 'node:url'
+import os from 'node:os'
 import path from 'node:path'
-import { test, expect, beforeAll } from 'vitest'
+import { test, expect, beforeAll, afterAll } from 'vitest'
 
 import { run, createServer } from '../src/index.js'
 
-const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
+const originalRunmeBinDir = process.env.RUNME_BIN_DIR
+let runmeBinDir: string
 
 beforeAll(async () => {
-  await fs.rm(
-    path.resolve(__dirname, '..', '.bin'),
-    { recursive: true, force: true }
-  )
+  runmeBinDir = await fs.mkdtemp(path.join(os.tmpdir(), 'runmejs-bin-'))
+  process.env.RUNME_BIN_DIR = runmeBinDir
+})
+
+afterAll(async () => {
+  if (originalRunmeBinDir) {
+    process.env.RUNME_BIN_DIR = originalRunmeBinDir
+  } else {
+    delete process.env.RUNME_BIN_DIR
+  }
+  await fs.rm(runmeBinDir, { recursive: true, force: true })
 })
 
 test('run', async () => {


### PR DESCRIPTION
## Summary

- move Runme binary downloads to `https://downloads.runme.dev/runme`
- allow tests to isolate the downloaded binary cache with `RUNME_BIN_DIR`
- mock the installer in the CLI unit test so it no longer downloads a real cross-platform binary
- reset downloader test mocks/env between cases to avoid hidden order dependence

## Why

The release workflow was failing because concurrent Vitest files could write different binaries into the same `./.bin/runme` path.

`tests/module.test.ts` downloads and executes a real Linux binary. `tests/cli.test.ts` mocked the OS as Darwin/arm64 but still reached the real downloader, which could write a Darwin binary into the same location while the module test expected Linux x64. On Ubuntu this reproduced as `ETXTBSY`, `SIGSEGV`, and Go runtime symbol-table corruption.

## Verification

- `npm ci --ignore-scripts`
- `runme run build test`
- Ubuntu 24.04 x64 Docker repro with Node `v24.18.0`, npm upgraded to latest, and Runme `3.17.1`: `runme run build test`
